### PR TITLE
Fixed added white space before concatenating words from tika analysis

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Unreleased
 The warc-indexer is now a single stand alone maven module extracted from the /webarchive-discovery/ project. All commit history has been preserved.
 * Upgrade third party dependencies and complete rewrite of the maven packing shading into uber-jar. This removed several duplicate dependencies clashes and the uber-jar has shrunk from 175MB to 147MB. Thanks to @Asger-KB (Asger) for the PR:  https://github.com/netarchivesuite/warc-indexer/pull/3
 * Next release will be 3.4.0 and will require extensive testing and performance measuring. No breaking changes are expected.
+* Fixed (regression error?) that sometimes words where concatenated without white space from tika analysis.
 
 3.3.1
 -----

--- a/conf/config3.conf
+++ b/conf/config3.conf
@@ -154,7 +154,7 @@
                     "text_extract_postcodes" : false,
                     #  Language profiles to load for langdetect
                     "language" : {
-                      #'da' and 'en' first 
+                      #'da' and 'en' first. For performance boots put the most common language in top.
                         "langdetectprofiles" : [
                             "en",
                             "da",
@@ -274,6 +274,6 @@
                 "max_text_length" : "512K"
             }
         },
-        "title" : "Default SB warc-indexer 3.0 config."
+        "title" : "Default Warc-indexer 3.4.0 config."
     }
 }

--- a/src/main/java/uk/bl/wa/solr/SolrRecordFactory.java
+++ b/src/main/java/uk/bl/wa/solr/SolrRecordFactory.java
@@ -180,7 +180,7 @@ public class SolrRecordFactory {
 
         // Remove control characters
         if (isEnabled(config, KEY_REMOVE_CONTROL_CHARACTERS, DEFAULT_REMOVE_CONTROL_CHARACTERS)) {
-            pipeline = pipeline.andThen(s -> CNTRL_PATTERN.matcher(s).replaceAll(""));
+            pipeline = pipeline.andThen(s -> CNTRL_PATTERN.matcher(s).replaceAll(" ")); //If replaced with empty string, some words will be concatenated without space.
             sb.append(sb.length() == 0 ? "" : ", ").append("remove_control_characters");
         }
 

--- a/src/test/java/uk/bl/wa/solr/SolrRecordFactoryTest.java
+++ b/src/test/java/uk/bl/wa/solr/SolrRecordFactoryTest.java
@@ -75,4 +75,34 @@ public class SolrRecordFactoryTest {
         }
 
     }
+    
+
+    @Test
+    public void testFieldAdjuster() {
+        URL ref = Thread.currentThread().getContextClassLoader().getResource("reference.conf");
+        assertNotNull("The config reference.conf should exist", ref);
+        File configFilePath = new File(ref.getFile());
+        Config conf = ConfigFactory.parseFile(configFilePath);                
+        
+        SolrRecordFactory factory = SolrRecordFactory.createFactory(conf);        
+        String field="content_text";
+        String value;
+        String result;
+        
+        value="Very simple text";
+        result = factory.applyAdjustment(field, value);
+        assertEquals(value,result);
+        
+        value="Lots\rof\ncontrol characters"; //both has \n (new line) and \r ( carriage return)
+        result = factory.applyAdjustment(field, value);
+        assertEquals("Lots of control characters",result);
+        
+        value="Some$special#characters"; //these are not removed
+        result = factory.applyAdjustment(field, value);
+        assertEquals("Some$special#characters",result);
+        
+        
+    }
+    
+    
 }


### PR DESCRIPTION
This will PR will fix more situations where words were concatened from Tika analysis without adding white space between words.
The resulted in search for those words would not be found in the document. And for text extracting the text will also be correct.