### PR TITLE
Fix tika ocr null pointer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -180,6 +180,17 @@
         </plugins>
     </build>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.tika</groupId>
+                <artifactId>tika-bom</artifactId>
+                <version>2.9.4</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!--Common modules start-->
@@ -247,13 +258,11 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-core</artifactId>
-            <version>2.9.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parsers-standard-package</artifactId>
-            <version>2.9.4</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -269,13 +278,11 @@
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-parser-html-commons</artifactId>
-            <version>2.9.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.tika</groupId>
             <artifactId>tika-langdetect-optimaize</artifactId>
-            <version>2.9.4</version>
         </dependency>
 
         <dependency>
@@ -509,6 +516,6 @@
             <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
-               
+
     </dependencies>
 </project>

--- a/src/main/java/uk/bl/wa/analyser/payload/TikaPayloadAnalyser.java
+++ b/src/main/java/uk/bl/wa/analyser/payload/TikaPayloadAnalyser.java
@@ -263,7 +263,10 @@ mime_exclude = x-tar,x-gzip,bz,lz,compress,zip,javascript,css,octet-stream,image
         if( embedded == null )
             embedded = new NonRecursiveEmbeddedDocumentExtractor(context);
         context.set( EmbeddedDocumentExtractor.class, embedded );
-        
+
+        //If not set, you will get a NullPointer from ParseRunner.run() as Tika tries to perform OCR on PDF files
+        context.set ( Parser.class, tika.getParser());
+
         try {
             final long parseStart = System.nanoTime();
             ParseRunner runner = new ParseRunner( source, tika.getParser(), tikainput, this.getHandler( content ), metadata, context );


### PR DESCRIPTION
The problem was this method in EmbeddedDocumentUtils

```
    /**
     * Utility function to get the Parser that was sent in to the
     * ParseContext to handle embedded documents.  If it is stateful,
     * unwrap it to get its stateless delegating parser.
     * <p>
     * If there is no Parser in the parser context, this will return null.
     *
     * @param context
     * @return
     */
    public static Parser getStatelessParser(ParseContext context) {
        Parser p = context.get(Parser.class);
        if (p == null) {
            return null;
        }
        if (p instanceof StatefulParser) {
            return ((StatefulParser) p).getWrappedParser();
        }
        return p;
    }
 ```
 
 It gave null which continued to AbstractPdf2XHTML.java
 
```
  if (config.getOcrStrategy() == NO_OCR) {
            ocrParser = null;
        } else {
            ocrParser = EmbeddedDocumentUtil.getStatelessParser(context);
        }
```

which then nullpointered in

```
 void doOCROnCurrentPage(PDPage pdPage, PDFParserConfig.OCR_STRATEGY ocrStrategy)
            throws IOException, TikaException, SAXException {
        if (ocrStrategy.equals(NO_OCR)) {
            return;
        }
        MediaType ocrImageMediaType = MediaType.image("ocr-" + config.getOcrImageFormatName());
        if (!ocrParser.getSupportedTypes(context).contains(ocrImageMediaType)) {
            if (ocrStrategy == OCR_ONLY || ocrStrategy == OCR_AND_TEXT_EXTRACTION) {
                throw new TikaException(
                        "" + "I regret that I couldn't find an OCR parser to handle " +
                                ocrImageMediaType + "." +
                                "Please set the OCR_STRATEGY to NO_OCR or configure your" +
                                "OCR parser correctly");
            } else if (ocrStrategy == AUTO) {
                //silently skip if there's no parser to run ocr
                return;
            }
        }
        ...
```        