### PR TITLE
External service solr field enricher

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,11 @@
 **NOTE** Generally, we only add terms to the Solr schema, so it should usually be compatible with previous versions (i.e. clients should be able to query across both without modification). However, there are been a small number of fixes which unfortunately required breaking changes you may need to be aware of or work-around. e.g. [hash becomes single-valued](https://github.com/ukwa/webarchive-discovery/issues/95) from 3.0.0 to 3.1.0
 
 Unreleased
- * Added support for calling an external service to enrich solr fields. See the config3.xml 'enrich' property for documentation. <br>
+* Added support for calling an external service to enrich solr fields. See the config3.xml 'enrich' property for documentation. <br>
   Implementation is in the  ExternalServiceSolrFieldEnricher. The service will be called for each record in the WARC file.<br>
   Config has custom mapping from solr to json (request) and from request to solr (response), to make service independant of solr fields.
+* 4 new Solr fields added to support service integration to safe-warc: sfw_probability,is_nsfw,is_virus,virus_description
+* For safe-warc service see: https://github.com/natliblux/warc-safe
 * Warc-indexer config3.xml bumped to version 3.5
 
 3.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 **NOTE** Generally, we only add terms to the Solr schema, so it should usually be compatible with previous versions (i.e. clients should be able to query across both without modification). However, there are been a small number of fixes which unfortunately required breaking changes you may need to be aware of or work-around. e.g. [hash becomes single-valued](https://github.com/ukwa/webarchive-discovery/issues/95) from 3.0.0 to 3.1.0
 
 Unreleased
+ * Added support for calling an external service to enrich solr fields. See the config3.xml 'enrich' property for documentation. <br>
+  Implementation is in the  ExternalServiceSolrFieldEnricher. The service will be called for each record in the WARC file.<br>
+  In the config3.xml see the property 'enrich' and it can be enabled. 
 
 
 3.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 Unreleased
  * Added support for calling an external service to enrich solr fields. See the config3.xml 'enrich' property for documentation. <br>
+  To use enable in the config and correct server-url and field sendt to service <br>
   Implementation is in the  ExternalServiceSolrFieldEnricher. The service will be called for each record in the WARC file.<br>
-  In the config3.xml see the property 'enrich' and it can be enabled. 
 
 
 3.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,8 +4,8 @@ Unreleased
 * Added support for calling an external service to enrich solr fields. See the config3.xml 'enrich' property for documentation. <br>
   Implementation is in the  ExternalServiceSolrFieldEnricher. The service will be called for each record in the WARC file.<br>
   Config has custom mapping from solr to json (request) and from request to solr (response), to make service independant of solr fields.
-* 4 new Solr fields added to support service integration to safe-warc: sfw_probability,is_nsfw,is_virus,virus_description
-* For safe-warc service see: https://github.com/natliblux/warc-safe
+* 4 new Solr fields added to support service integration to warc-safe: nfw_probability,is_nsfw,is_virus,virus_description
+* For warc-safe service see: https://github.com/natliblux/warc-safe
 * Warc-indexer config3.xml bumped to version 3.5
 
 3.4.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,9 +2,9 @@
 
 Unreleased
  * Added support for calling an external service to enrich solr fields. See the config3.xml 'enrich' property for documentation. <br>
-  To use enable in the config and correct server-url and field sendt to service <br>
   Implementation is in the  ExternalServiceSolrFieldEnricher. The service will be called for each record in the WARC file.<br>
-
+  Config has custom mapping from solr to json (request) and from request to solr (response), to make service independant of solr fields.
+* Warc-indexer config3.xml bumped to version 3.5
 
 3.4.0
 -----

--- a/conf/config3.conf
+++ b/conf/config3.conf
@@ -274,6 +274,12 @@
                 "max_text_length" : "512K"
             }
         },
+        # Enrich
+         "enrich":{
+            "enabled": true,
+            "server_url":"http://localhost:8888/warc-safe"
+         }       
+
         "title" : "Default Warc-indexer 3.4.0 config."
     }
 }

--- a/conf/config3.conf
+++ b/conf/config3.conf
@@ -1,5 +1,7 @@
 {
     "warc" : {
+      "title" : "Default Warc-indexer 3.5.0 config."
+    
         #  HTTP Proxy to use when talking to Solr (if any):
         "http_proxy" : {},
         #  Solr configuration:
@@ -301,8 +303,6 @@
                "is_virus -> is_virus",
                "av_details -> virus_description"            
             ]            
-         }       
-
-        "title" : "Default Warc-indexer 3.5.0 config."
+         }             
     }
 }

--- a/conf/config3.conf
+++ b/conf/config3.conf
@@ -274,29 +274,32 @@
                 "max_text_length" : "512K"
             }
         },
-        # Enrich Solr fields. Call a webservice with POST request to enrich olr fields with additional data.
+        # Enrich Solr fields. Call a webservice with POST request to enrich Solr fields with additional data.
         #        
-        # The JSON response will overwrite the Solr fields with the values from the response. Define which values to overwrite in the jsonFieldsInResponse list below.
-        # Values will only be overwritten if it is contained in the response.     
+        # The JSON response will overwrite the Solr fields with the values from the response. Define which values to overwrite in the 'jsonFields2SolrFields' list below.
+        # Values will only be overwritten if it is contained in the response and field is defined in 'jsonFields2SolrFields' field list   
         # The service will be called for each record in the WARC-file. POST data will be a JSON object with key/value from the fully populated Solr document.
-        # Define the list of Solr key/value pairs in the list property: solrFieldsInRequest  <br>
+        # Define the list of Solr fields extracted and what each field is mapped to as json in the 'solrField2JsonFields' list <br>
         #
-        # The service must return a JSON object. Key/values will overwrite the Solr fields if they are present in the response. <br>
-        # Will only overwrite Solr records that are define the list property: jsonFieldsInResponse <br>      
-        # Fields must be defined in the solr.xml and configuration uploaded to Solr.    
-        # Enrich service example, see https://github.com/natliblux/warc-safe   
+        # The service must return a JSON object. Key/values will overwrite the Solr fields if they are present in the response. <br>      
+        # Fields must be defined in the schema.xml and configuration uploaded to Solr.    
+        # Enrich service example, see https://github.com/natliblux/warc-safe         
+           
          "enrich":{
-            "enabled": false, # Enable it here to make it active.
-            "server_url":"http://localhost:8000/warc-safe/test_all" #Notice this service does not take offset-parameter yet
-            "solrFieldsInRequest" : [
-                "source_file_path",
-                "source_file_offset"
+            "enabled": true, # Enable it here to make it active.
+            "server_url":"http://localhost:8000/test_all"              
+            "solrField2JsonFields" : [
+                ## Define mapping from solr fields to json attributes for external service call          
+                ## Solr field name  -> json attribute name
+                "source_file_path -> file_path",                   
+                "source_file_offset -> offset"                
             ],
-            "jsonFieldsInResponse" : [ # Case sensitive. Must be defined in solr schema (solr.xml)
-               "nsfw_probability",
-               "is_nsfw",
-               "is_virus",
-               "virus_description"
+            "jsonFields2SolrFields" : [ # Case sensitive. Must be defined in solr schema (schema.xml)               
+               ## Define mapping from JSON response to Solr fields.
+               "nsfw_score -> nsfw_probability",
+               "is_nsfw -> is_nsfw",  ## NEEDS NEW FIELD IN RESPONSE
+               "is_virus -> is_virus", ## NEEDS NEW FIELD IN RESPONSE
+               "av_details -> virus_description"            
             ]            
          }       
 

--- a/conf/config3.conf
+++ b/conf/config3.conf
@@ -274,12 +274,32 @@
                 "max_text_length" : "512K"
             }
         },
-        # Enrich
+        # Enrich Solr fields. Call a webservice with POST request to enrich olr fields with additional data.
+        #        
+        # The JSON response will overwrite the Solr fields with the values from the response. Define which values to overwrite in the jsonFieldsInResponse list below.
+        # Values will only be overwritten if it is contained in the response.     
+        # The service will be called for each record in the WARC-file. POST data will be a JSON object with key/value from the fully populated Solr document.
+        # Define the list of Solr key/value pairs in the list property: solrFieldsInRequest  <br>
+        #
+        # The service must return a JSON object. Key/values will overwrite the Solr fields if they are present in the response. <br>
+        # Will only overwrite Solr records that are define the list property: jsonFieldsInResponse <br>      
+        # Fields must be defined in the solr.xml and configuration uploaded to Solr.    
+        # Enrich service example, see https://github.com/natliblux/warc-safe   
          "enrich":{
-            "enabled": true,
-            "server_url":"http://localhost:8888/warc-safe"
+            "enabled": false, # Enable it here to make it active.
+            "server_url":"http://localhost:8000/warc-safe/test_all" #Notice this service does not take offset-parameter yet
+            "solrFieldsInRequest" : [
+                "source_file_path",
+                "source_file_offset"
+            ],
+            "jsonFieldsInResponse" : [ # Case sensitive. Must be defined in solr schema (solr.xml)
+               "nsfw_probability",
+               "is_nsfw",
+               "is_virus",
+               "virus_description"
+            ]            
          }       
 
-        "title" : "Default Warc-indexer 3.4.0 config."
+        "title" : "Default Warc-indexer 3.5.0 config."
     }
 }

--- a/conf/config3.conf
+++ b/conf/config3.conf
@@ -297,8 +297,8 @@
             "jsonFields2SolrFields" : [ # Case sensitive. Must be defined in solr schema (schema.xml)               
                ## Define mapping from JSON response to Solr fields.
                "nsfw_score -> nsfw_probability",
-               "is_nsfw -> is_nsfw",  ## NEEDS NEW FIELD IN RESPONSE
-               "is_virus -> is_virus", ## NEEDS NEW FIELD IN RESPONSE
+               "is_nsfw -> is_nsfw",
+               "is_virus -> is_virus",
                "av_details -> virus_description"            
             ]            
          }       

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <packaging>jar</packaging>
     <name>warc-indexer</name>
     <url>https://maven.apache.org</url>
-    <version>3.4.0</version>
+    <version>3.5.0-SNAPSHOT</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -63,8 +63,7 @@ public class ExternalServiceSolrFieldEnricher {
     /*
      * Map values in service response to solr field names and values
      */    
-    public HashMap<String,String> getSolrEnrichmentFields(HashMap<String,String> jsonRequestParameters) throws Exception{          
-    System.out.println("json map input:"+jsonRequestParameters);
+    public HashMap<String,String> getSolrEnrichmentFields(HashMap<String,String> jsonRequestParameters) throws Exception{              
         String json=generateJsonObject(jsonRequestParameters);               
 
         String jsonResponse=callService( json);
@@ -90,7 +89,7 @@ public class ExternalServiceSolrFieldEnricher {
             return null;
         }
         String responseStr = new BasicResponseHandler().handleResponse(response);   
-        log.debug("External service JSON:"+responseStr);
+        //log.debug("External service JSON:"+responseStr);
         return responseStr;       
     }
     

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -46,7 +46,7 @@ public class ExternalServiceSolrFieldEnricher {
     public static void main(String[] args) throws Exception{    
         //String url="http://localhost:8000/warc-safe/new_method";
         String url="http://localhost:8000/";
-        List<String>fieldsToExtract=  new ArrayList<String>(); // This is the fields that will be extracted from the response(if present)        
+        List<String> fieldsToExtract=  new ArrayList<String>(); // This is the fields that will be extracted from the response(if present)        
         fieldsToExtract.add("nsfw_probability");
         fieldsToExtract.add("is_nsfw");
         fieldsToExtract.add("is_virus");

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -2,10 +2,10 @@ package uk.bl.wa.indexer;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpPost;
@@ -26,60 +26,55 @@ import org.slf4j.LoggerFactory;
  * The service must return a JSON object. Key/values will overwrite the Solr fields if they are present in the response. <br>
  * Will only overwrite Solr records that are define the list property: jsonFieldsInResponse <br>
  * <br>
- * This class has a main method for easy integration test to the external service.
+ * See  ExternalServiceSolrFieldEnricherIntegrationTest for easy way to test an existing enrichment service.
  */
 public class ExternalServiceSolrFieldEnricher {
     private static Logger log = LoggerFactory.getLogger(ExternalServiceSolrFieldEnricher.class);
     private String serverUrl;
-    private HashSet<String> fieldsToExtract;
+    private HashMap<String,String> solrFields2ToJsonAttributes;
+    private HashMap<String,String> jsonAttributes2SolrFields;
+
     HttpClient httpClient = null;
     
-    public ExternalServiceSolrFieldEnricher(String serverUrl,  List<String> fieldsToExtract) {                
+    public ExternalServiceSolrFieldEnricher(String serverUrl, List<String> solrFields2ToJsonAttributesList, List<String>jsonAttributes2SolrFieldsList) {                                       
         this.serverUrl=serverUrl;
-        this.fieldsToExtract=new HashSet<String>(fieldsToExtract);
+        this.solrFields2ToJsonAttributes=getFieldMapping(jsonAttributes2SolrFieldsList);
+        this.jsonAttributes2SolrFields=getFieldMapping(jsonAttributes2SolrFieldsList);        
         httpClient = HttpClientBuilder.create().build();
     }
-    
-    /**
-     *  Convenience main method to manual call and test an external webservice. Easy to run from IDE. 
+          
+    /*
+     * Extract only the solr field defined in the mapping
      */
-    public static void main(String[] args) throws Exception{    
-        //String url="http://localhost:8000/warc-safe/new_method";
-        String url="http://localhost:8000/";
-        List<String> fieldsToExtract=  new ArrayList<String>(); // This is the fields that will be extracted from the response(if present)        
-        fieldsToExtract.add("nsfw_probability");
-        fieldsToExtract.add("is_nsfw");
-        fieldsToExtract.add("is_virus");
-        fieldsToExtract.add("virus_description");
-        
-        ExternalServiceSolrFieldEnricher enrichService= new ExternalServiceSolrFieldEnricher(url,fieldsToExtract);
+    protected HashMap<String,String> extractSolrFieldsFromResponse(HashMap<String,String> jsonReponse) throws Exception{          
+    
+        HashMap<String,String>  solrFields= new HashMap<String,String>();
+        for (String jsonKey: jsonReponse.keySet()) {
+            String solrKey=jsonAttributes2SolrFields.get(jsonKey);
+            if (solrKey != null) { //This is one of the values to index
+             solrFields.put(solrKey, jsonReponse.get(jsonKey));                
+            }                            
+        }        
+        return  solrFields;
+    }
 
-        HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();
-        jsonRequestParameters.put("file_path","/home/xxx/test.warc.gz");
-        jsonRequestParameters.put("offset","1234565");
+    /*
+     * Map values in service response to solr field names and values
+     */    
+    public HashMap<String,String> getSolrEnrichmentFields(HashMap<String,String> jsonRequestParameters) throws Exception{          
+        String json=generateJsonObject(jsonRequestParameters);               
+        String jsonResponse=callService( json);
+        HashMap<String, String> jsonFromService = parseJsonMapToJavaMap(jsonResponse);        
+        HashMap<String, String> solrFields = extractSolrFieldsFromResponse(jsonFromService);
+        return solrFields;
+
         
-        String json= enrichService.generateJsonObject(jsonRequestParameters);               
-        System.out.println("POST json to service:"+json);
-        String jsonResponse = enrichService.callService( json);
-        System.out.println("Service response:"+json);
-        
-        HashMap<String, String> solrfields = enrichService.parseJsonMapToJavaMap(jsonResponse);        
-        System.out.println("Extraced solr fields and value:"+solrfields);        
     }
     
     
-    public HashMap<String,String> extractEnrichFields (HashMap<String,String> jsonRequestParameters) throws Exception{          
-        String json= generateJsonObject(jsonRequestParameters);                
-        String jsonResponse = callService(json);              
-        if (jsonResponse == null) {
-            return new HashMap<String, String>();
-        }
-        HashMap<String, String> solrfields = parseJsonMapToJavaMap(jsonResponse);       
-        return solrfields;                  
-    }
-    
-    private String callService(String json) throws Exception{       
-        HttpPost     post          = new HttpPost(serverUrl);
+    protected String callService(String json) throws Exception{       
+        log.debug("Calling external service with JSON:"+json);
+        HttpPost post = new HttpPost(serverUrl);
         StringEntity postingString = new StringEntity(json);
         post.setEntity(postingString);               
         post.setHeader("Content-type", "application/json");
@@ -87,36 +82,57 @@ public class ExternalServiceSolrFieldEnricher {
         HttpResponse  response = httpClient.execute(post); 
         int statusCode= response.getStatusLine().getStatusCode();
         if (statusCode != 200) {
-            log.warn("Not http 200 status from calling enrich service with json:"+json);
+            log.warn("Not http 200 status from calling enrich service. Statuscode="+statusCode +" Json:"+json);
             return null;
         }
         String responseStr = new BasicResponseHandler().handleResponse(response);   
+        log.debug("External service JSON:"+responseStr);
         return responseStr;       
     }
     
-    private String generateJsonObject(HashMap<String,String> parameters) {        
+    protected String generateJsonObject(HashMap<String,String> parameters) {        
         JSONObject json=new JSONObject();
         for (String key:parameters.keySet()) {            
-           json.put(key, parameters.get(key));
+             String value=parameters.get(key);
+              boolean numeric=StringUtils.isNumeric(value);
+             if (numeric) {
+                json.put(key, Integer.valueOf(value));
+             }
+             else{
+                 json.put(key, value);
+             }
         }                
         return json.toString();                             
     }
     
     @SuppressWarnings("unchecked")
-    private HashMap<String, String> parseJsonMapToJavaMap( String jsonString) {                
-        HashMap<String, String> extractedSolrFieldsAndValues = new HashMap<String, String>(); 
+    protected HashMap<String, String> parseJsonMapToJavaMap( String jsonString) {                
+        HashMap<String, String> jsonKeyValueMap = new HashMap<String, String>(); 
         JSONObject json=new JSONObject(jsonString);
         Set<String> attributes = (Set<String>) json.keySet();
         for (String key:attributes) {
-            Object object = json.get((String) key);
-            if (object instanceof String ) { //Ignore arrays ( multivalue)                           
-                if (fieldsToExtract.contains(key)) {
-                    String value=(String) object;
-                    extractedSolrFieldsAndValues.put(key, value);                    
-                    System.out.println("Added Key:"+key +" value:"+value);
-                }                
-            }            
+           Object object = json.get((String) key);                                                              
+           jsonKeyValueMap.put(key, (String) object.toString());            
         }
-        return extractedSolrFieldsAndValues;        
+        return jsonKeyValueMap;        
     }       
+
+    /*
+     * Map strings to map: 'source_file_path -> file_path'
+     * Will be map element with (source_file_path, file_path) 
+     */
+    protected static HashMap<String,String> getFieldMapping( List<String> propertyMappingString){    
+        HashMap<String,String> fieldMapping= new HashMap<String,String>();
+        //Parse into map
+        for (String field : propertyMappingString) {                                
+            String[] keyVal=field.split("->");                 
+            fieldMapping.put(keyVal[0].trim(),keyVal[1].trim());                                   
+        }                 
+        return fieldMapping;        
+    }
+    
+    public HashMap<String,String> getSolrFields2JsonAttributes(){              
+        return solrFields2ToJsonAttributes;
+    }
+
 }

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -38,7 +38,7 @@ public class ExternalServiceSolrFieldEnricher {
     
     public ExternalServiceSolrFieldEnricher(String serverUrl, List<String> solrFields2ToJsonAttributesList, List<String>jsonAttributes2SolrFieldsList) {                                       
         this.serverUrl=serverUrl;
-        this.solrFields2ToJsonAttributes=getFieldMapping(jsonAttributes2SolrFieldsList);
+        this.solrFields2ToJsonAttributes=getFieldMapping(solrFields2ToJsonAttributesList);
         this.jsonAttributes2SolrFields=getFieldMapping(jsonAttributes2SolrFieldsList);        
         httpClient = HttpClientBuilder.create().build();
     }
@@ -62,7 +62,9 @@ public class ExternalServiceSolrFieldEnricher {
      * Map values in service response to solr field names and values
      */    
     public HashMap<String,String> getSolrEnrichmentFields(HashMap<String,String> jsonRequestParameters) throws Exception{          
+    System.out.println("json map input:"+jsonRequestParameters);
         String json=generateJsonObject(jsonRequestParameters);               
+
         String jsonResponse=callService( json);
         HashMap<String, String> jsonFromService = parseJsonMapToJavaMap(jsonResponse);        
         HashMap<String, String> solrFields = extractSolrFieldsFromResponse(jsonFromService);

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -107,10 +107,10 @@ public class ExternalServiceSolrFieldEnricher {
     @SuppressWarnings("unchecked")
     protected HashMap<String, String> parseJsonMapToJavaMap( String jsonString) {                
         HashMap<String, String> jsonKeyValueMap = new HashMap<String, String>(); 
-        JSONObject json=new JSONObject(jsonString);
         if (jsonString == null || jsonString.isBlank()) { //In case null response from service.
             return jsonKeyValueMap;
-        }        
+        }
+        JSONObject json=new JSONObject(jsonString);        
         Set<String> attributes = (Set<String>) json.keySet();
         for (String key:attributes) {
            Object object = json.get((String) key);                                                              

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -1,0 +1,122 @@
+package uk.bl.wa.indexer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.impl.client.BasicResponseHandler;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class can enrich solr fields from an external service. <br>
+ * <br>
+ * In the config3.xml see the property 'enrich' and it can be enabled.  <br>
+ * The service will be called from each record in the WARC-file and POST data will be a JSON object  <br> 
+ * with key/value from the fully populated Solr document. Define the list of Solr key/value pairs in the list property: solrFieldsInRequest  <br>
+ * <br>
+ * The service must return a JSON object. Key/values will overwrite the Solr fields if they are present in the response. <br>
+ * Will only overwrite Solr records that are define the list property: jsonFieldsInResponse <br>
+ * <br>
+ * This class has a main method for easy integration test to the external service.
+ */
+public class ExternalServiceSolrFieldEnricher {
+    private static Logger log = LoggerFactory.getLogger(ExternalServiceSolrFieldEnricher.class);
+    private String serverUrl;
+    private HashSet<String> fieldsToExtract;
+    HttpClient httpClient = null;
+    
+    public ExternalServiceSolrFieldEnricher(String serverUrl,  List<String> fieldsToExtract) {                
+        this.serverUrl=serverUrl;
+        this.fieldsToExtract=new HashSet<String>(fieldsToExtract);
+        httpClient = HttpClientBuilder.create().build();
+    }
+    
+    /**
+     *  Convenience main method to manual call and test an external webservice. Easy to run from IDE. 
+     */
+    public static void main(String[] args) throws Exception{    
+        //String url="http://localhost:8000/warc-safe/new_method";
+        String url="http://localhost:8000/";
+        List<String>fieldsToExtract=  new ArrayList<String>(); // This is the fields that will be extracted from the response(ir present)        
+        fieldsToExtract.add("nsfw_probability");
+        fieldsToExtract.add("is_nsfw");
+        fieldsToExtract.add("is_virus");
+        fieldsToExtract.add("virus_description");
+        
+        ExternalServiceSolrFieldEnricher enrichService= new ExternalServiceSolrFieldEnricher(url,fieldsToExtract);
+
+        HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();
+        jsonRequestParameters.put("file_path","/home/xxx/test.warc.gz");
+        jsonRequestParameters.put("offset","1234565");
+        
+        String json= enrichService.generateJsonObject(jsonRequestParameters);               
+        System.out.println("POST json to service:"+json);
+        String jsonResponse = enrichService.callService( json);
+        System.out.println("Service response:"+json);
+        
+        HashMap<String, String> solrfields = enrichService.parseJsonMapToJavaMap(jsonResponse);        
+        System.out.println("Extraced solr fields and value:"+solrfields);        
+    }
+    
+    
+    public HashMap<String,String> extractEnrichFields (HashMap<String,String> jsonRequestParameters) throws Exception{          
+        String json= generateJsonObject(jsonRequestParameters);                
+        String jsonResponse = callService(json);              
+        if (jsonResponse == null) {
+            return new HashMap<String, String>();
+        }
+        HashMap<String, String> solrfields = parseJsonMapToJavaMap(jsonResponse);       
+        return solrfields;                  
+    }
+    
+    private String callService(String json) throws Exception{       
+        HttpPost     post          = new HttpPost(serverUrl);
+        StringEntity postingString = new StringEntity(json);
+        post.setEntity(postingString);               
+        post.setHeader("Content-type", "application/json");
+        post.setHeader("Accept", "application/json");
+        HttpResponse  response = httpClient.execute(post); 
+        int statusCode= response.getStatusLine().getStatusCode();
+        if (statusCode != 200) {
+            log.warn("Not http 200 status from calling enrich service with json:"+json);
+            return null;
+        }
+        String responseStr = new BasicResponseHandler().handleResponse(response);   
+        return responseStr;       
+    }
+    
+    private String generateJsonObject(HashMap<String,String> parameters) {        
+        JSONObject json=new JSONObject();
+        for (String key:parameters.keySet()) {            
+           json.put(key, parameters.get(key));
+        }                
+        return json.toString();                             
+    }
+    
+    @SuppressWarnings("unchecked")
+    private HashMap<String, String> parseJsonMapToJavaMap( String jsonString) {                
+        HashMap<String, String> extractedSolrFieldsAndValues = new HashMap<String, String>(); 
+        JSONObject json=new JSONObject(jsonString);
+        Set<String> attributes = (Set<String>) json.keySet();
+        for (String key:attributes) {
+            Object object = json.get((String) key);
+            if (object instanceof String ) { //Ignore arrays ( multivalue)                           
+                if (fieldsToExtract.contains(key)) {
+                    String value=(String) object;
+                    extractedSolrFieldsAndValues.put(key, value);                    
+                    System.out.println("Added Key:"+key +" value:"+value);
+                }                
+            }            
+        }
+        return extractedSolrFieldsAndValues;        
+    }       
+}

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.HttpResponse;
@@ -40,7 +41,8 @@ public class ExternalServiceSolrFieldEnricher {
         this.serverUrl=serverUrl;
         this.solrFields2ToJsonAttributes=getFieldMapping(solrFields2ToJsonAttributesList);
         this.jsonAttributes2SolrFields=getFieldMapping(jsonAttributes2SolrFieldsList);        
-        httpClient = HttpClientBuilder.create().build();
+        httpClient = HttpClientBuilder.create().setConnectionTimeToLive(10,TimeUnit.SECONDS).build(); //10 second timeout
+    
     }
           
     /*

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -41,8 +41,7 @@ public class ExternalServiceSolrFieldEnricher {
         this.serverUrl=serverUrl;
         this.solrFields2ToJsonAttributes=getFieldMapping(solrFields2ToJsonAttributesList);
         this.jsonAttributes2SolrFields=getFieldMapping(jsonAttributes2SolrFieldsList);        
-        httpClient = HttpClientBuilder.create().setConnectionTimeToLive(10,TimeUnit.SECONDS).build(); //10 second timeout
-    
+        httpClient = HttpClientBuilder.create().setConnectionTimeToLive(10,TimeUnit.SECONDS).build(); //10 second timeout    
     }
           
     /*
@@ -69,12 +68,9 @@ public class ExternalServiceSolrFieldEnricher {
         String jsonResponse=callService( json);
         HashMap<String, String> jsonFromService = parseJsonMapToJavaMap(jsonResponse);        
         HashMap<String, String> solrFields = extractSolrFieldsFromResponse(jsonFromService);
-        return solrFields;
-
-        
+        return solrFields;        
     }
-    
-    
+        
     protected String callService(String json) throws Exception{       
         log.debug("Calling external service with JSON:"+json);
         HttpPost post = new HttpPost(serverUrl);

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -108,6 +108,9 @@ public class ExternalServiceSolrFieldEnricher {
     protected HashMap<String, String> parseJsonMapToJavaMap( String jsonString) {                
         HashMap<String, String> jsonKeyValueMap = new HashMap<String, String>(); 
         JSONObject json=new JSONObject(jsonString);
+        if (jsonString == null || jsonString.isBlank()) { //In case null response from service.
+            return jsonKeyValueMap;
+        }        
         Set<String> attributes = (Set<String>) json.keySet();
         for (String key:attributes) {
            Object object = json.get((String) key);                                                              

--- a/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
+++ b/src/main/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricher.java
@@ -46,7 +46,7 @@ public class ExternalServiceSolrFieldEnricher {
     public static void main(String[] args) throws Exception{    
         //String url="http://localhost:8000/warc-safe/new_method";
         String url="http://localhost:8000/";
-        List<String>fieldsToExtract=  new ArrayList<String>(); // This is the fields that will be extracted from the response(ir present)        
+        List<String>fieldsToExtract=  new ArrayList<String>(); // This is the fields that will be extracted from the response(if present)        
         fieldsToExtract.add("nsfw_probability");
         fieldsToExtract.add("is_nsfw");
         fieldsToExtract.add("is_virus");

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -420,6 +420,7 @@ public class WARCIndexer {
             // -----------------------------------------------------
 
             processText(solr, isTextIncluded);
+                    
         }
         Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
                      "WARCIndexer.extract#total", start);

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexer.java
@@ -419,8 +419,7 @@ public class WARCIndexer {
             // Payload analysis complete, now performing text analysis:
             // -----------------------------------------------------
 
-            processText(solr, isTextIncluded);
-                    
+            processText(solr, isTextIncluded);                    
         }
         Instrument.timeRel("WARCIndexerCommand.parseWarcFiles#solrdocCreation",
                      "WARCIndexer.extract#total", start);

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -103,7 +103,6 @@ public class WARCIndexerCommand {
 
         // Check if the text field is required for the output (explicit (-t), Elasticsearch or Solr)
         final boolean isTextRequired = opts.includeText || opts.solrUrl != null || opts.opensearchUrl != null;
-
         try {
             parseWarcFiles(opts, isTextRequired);
         } finally {
@@ -148,14 +147,16 @@ public class WARCIndexerCommand {
         String enrichPropertyEnabled="warc.enrich.enabled";
         boolean enrichDefined=conf.hasPath("warc.enrich.enabled");        
         if (enrichDefined && conf.getBoolean(enrichPropertyEnabled)) { //Defined and true                       
-            List<String> solrFieldInRequest = conf.getStringList("warc.enrich.solrFieldsInRequest");
+            List<String> jsonFields2SolrFieldsList = conf.getStringList("warc.enrich.jsonFields2SolrFields");
+                        
             String serverUrl= conf.getString("warc.enrich.server_url");
-            enrichService = new ExternalServiceSolrFieldEnricher(serverUrl, solrFieldInRequest);       
-           log.info("Solr field enrich service initialised with url='{}' and using request fields='{}'", serverUrl, solrFieldInRequest);         
+            List<String> solrField2JsonFields= conf.getStringList("warc.enrich.solrField2JsonFields");
+            
+            enrichService = new ExternalServiceSolrFieldEnricher(serverUrl, jsonFields2SolrFieldsList, solrField2JsonFields);       
+           log.info("Solr field enrich service initialised with url='{}' and using request fields='{}' and solrmapping fields='{}'", serverUrl,  solrField2JsonFields,jsonFields2SolrFieldsList);         
         }
  
         
-
         // FIXME DUMP CONFIG OPTIONS
         // ConfigPrinter.print(conf);
         // conf.withOnlyPath("warc").root().render(ConfigRenderOptions.concise()));
@@ -263,7 +264,7 @@ public class WARCIndexerCommand {
 
     
     /**
-     * This method will enrich or overwrite Solr fields with values from an external service just before submitting the document to solr.
+     * This method will enrich   Solr fields with values from an external service just before submitting the document to solr.
      * Can be enabled in the config3.xml by property: warc.enric.enabled=true
      * The service will be called as a POST request with a JSON object with key/values from Solr fields. Defined as list in warc.enrich.solrFieldsInRequest 
      * The JSON response (key-values) will overwrite Solr fields. Define which fields to overwrite in warc.enrich.solrFieldsInRequest.jsonFieldsInResponse  
@@ -272,19 +273,24 @@ public class WARCIndexerCommand {
         final long start = System.nanoTime();
         Instrument.timeRel("WARCIndexer.extract#total","WARCIndexer.extract#external.service", start);  
         if(enrichService!= null) { //Will have been initialized at startup if enabled in config3.xml
-
-            List<String> solrFieldInRequest = conf.getStringList("warc.enrich.solrFieldsInRequest");
+            HashMap<String,String> solrFieldInRequestMapping=  enrichService.getSolrFields2JsonAttributes();
+                                    
             HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();
-            try {
-                //Send parameters in request
-                for (String field : solrFieldInRequest) {       
-                    jsonRequestParameters.put(field, doc.getFieldAsString(field));                    
-                }                                                      
-                HashMap<String, String> solrFieldsValues = enrichService.extractEnrichFields(jsonRequestParameters);
+            try {                                              
+                //Send parameters in request, mapped to JSON attribute name
+                for (String solrField : solrFieldInRequestMapping.keySet()) {       
+                    String attribute=solrFieldInRequestMapping.get(solrField);                       
+                    jsonRequestParameters.put(attribute, doc.getFieldAsString(solrField));                    
+                }               
+                
+                HashMap<String, String> solrFieldsValues  = enrichService.getSolrEnrichmentFields(jsonRequestParameters);                
+
                 //Add or overwrite solrfields
                 for (String field: solrFieldsValues.keySet()) {
+                    log.debug("Enriching with solr field:"+field +" value:"+solrFieldsValues.get(field));
                     doc.setField(field,solrFieldsValues.get(field)); //will overwrite. (setField and not addField)
-                }                
+                } 
+                              
             }
             catch(Exception e) {
                log.error("Error enrich Solr field from service call. Request parameters:"+jsonRequestParameters +" Error:"+e.getMessage());

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -144,9 +144,9 @@ public class WARCIndexerCommand {
         
         //Set up external service solr field enricher if defined in property-file
         ExternalServiceSolrFieldEnricher enrichService=null;
-        String enrichPropertyEnabled="warc.enrich.enabled";
+        String enrichProperty="warc.enrich.enabled";
         boolean enrichDefined=conf.hasPath("warc.enrich.enabled");        
-        if (enrichDefined && conf.getBoolean(enrichPropertyEnabled)) { //Defined and true                       
+        if (enrichDefined && conf.getBoolean(enrichProperty)) { //Defined and true                       
             List<String> solrField2JsonFields= conf.getStringList("warc.enrich.solrField2JsonFields");
             List<String> jsonFields2SolrFieldsList = conf.getStringList("warc.enrich.jsonFields2SolrFields");                        
             String serverUrl= conf.getString("warc.enrich.server_url");                        

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -147,16 +147,13 @@ public class WARCIndexerCommand {
         String enrichPropertyEnabled="warc.enrich.enabled";
         boolean enrichDefined=conf.hasPath("warc.enrich.enabled");        
         if (enrichDefined && conf.getBoolean(enrichPropertyEnabled)) { //Defined and true                       
-            List<String> jsonFields2SolrFieldsList = conf.getStringList("warc.enrich.jsonFields2SolrFields");
-                        
-            String serverUrl= conf.getString("warc.enrich.server_url");
             List<String> solrField2JsonFields= conf.getStringList("warc.enrich.solrField2JsonFields");
-            
-            enrichService = new ExternalServiceSolrFieldEnricher(serverUrl, jsonFields2SolrFieldsList, solrField2JsonFields);       
-           log.info("Solr field enrich service initialised with url='{}' and using request fields='{}' and solrmapping fields='{}'", serverUrl,  solrField2JsonFields,jsonFields2SolrFieldsList);         
+            List<String> jsonFields2SolrFieldsList = conf.getStringList("warc.enrich.jsonFields2SolrFields");                        
+            String serverUrl= conf.getString("warc.enrich.server_url");                        
+            enrichService = new ExternalServiceSolrFieldEnricher(serverUrl,  solrField2JsonFields,jsonFields2SolrFieldsList);       
+            log.info("Solr field enrich service initialised with url='{}' and using request fields='{}' and solrmapping fields='{}'", serverUrl,  solrField2JsonFields,jsonFields2SolrFieldsList);         
         }
- 
-        
+         
         // FIXME DUMP CONFIG OPTIONS
         // ConfigPrinter.print(conf);
         // conf.withOnlyPath("warc").root().render(ConfigRenderOptions.concise()));
@@ -287,10 +284,12 @@ public class WARCIndexerCommand {
 
                 //Add or overwrite solrfields
                 for (String field: solrFieldsValues.keySet()) {
-                    log.debug("Enriching with solr field:"+field +" value:"+solrFieldsValues.get(field));
-                    doc.setField(field,solrFieldsValues.get(field)); //will overwrite. (setField and not addField)
-                } 
-                              
+                    String solrValue=solrFieldsValues.get(field);
+                    if (solrValue != null) {
+                       log.debug("Enriching with solr field:"+field +" value:"+solrValue);                
+                       doc.setField(field,solrValue); //will overwrite. (setField and not addField)
+                    }
+                }                               
             }
             catch(Exception e) {
                log.error("Error enrich Solr field from service call. Request parameters:"+jsonRequestParameters +" Error:"+e.getMessage());

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -268,7 +268,7 @@ public class WARCIndexerCommand {
      */
     private static void enrichFromExternalService(Config conf, ExternalServiceSolrFieldEnricher enrichService, SolrRecord doc) {
         final long start = System.nanoTime();
-        Instrument.timeRel("WARCIndexer.extract#total","WARCIndexer.extract#external.service", start);  
+          
         if(enrichService!= null) { //Will have been initialized at startup if enabled in config3.xml
             HashMap<String,String> solrFieldInRequestMapping=  enrichService.getSolrFields2JsonAttributes();
                                     
@@ -295,6 +295,7 @@ public class WARCIndexerCommand {
                log.error("Error enrich Solr field from service call. Request parameters:"+jsonRequestParameters +" Error:"+e.getMessage());
             }                    
         }
+        Instrument.timeRel("WARCIndexer.extract#total","WARCIndexer.extract#external.service", start);
     }
     
 }

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -223,7 +223,18 @@ public class WARCIndexerCommand {
                     log.debug("No document produced by record: " + type + " for url " + url + " from " + 
                         inFile.getName() + " @" + rec.getHeader().getOffset()); //All request records will log this. It is expected there is no document.
             }
+      
+              //Optional enrich 
+
+              //TODO handle if not exists, method takes no default value(!?)  
+              String enabledProptery="warc.enrich.enabled";
+              boolean hasProperty=conf.hasPath("warc.enrich.enabled");
+              System.out.println("has property:"+hasProperty);
+              boolean enrich_enabled=conf.getBoolean("warc.enrich.enabled");
+              System.out.println("enrich:"+enrich_enabled);                        
             }
+                
+      
             docConsumer.endWARC();
             Instrument.timeRel("WARCIndexerCommand.main#total",
                                "WARCIndexerCommand.parseWarcFiles#fullarcprocess", arcStart);

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -8,6 +8,7 @@ import java.nio.charset.Charset;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.zip.GZIPOutputStream;
@@ -141,6 +142,19 @@ public class WARCIndexerCommand {
             
             conf = ConfigFactory.parseFile(configFilePath);
         }
+        
+        //Set up external service solr field enricher if defined in property-file
+        ExternalServiceSolrFieldEnricher enrichService=null;
+        String enrichPropertyEnabled="warc.enrich.enabled";
+        boolean enrich_enabled=conf.getBoolean(enrichPropertyEnabled);
+        if (enrich_enabled) {            
+            List<String> solrFieldInRequest = conf.getStringList("warc.enrich.solrFieldsInRequest");
+            String serverUrl= conf.getString("warc.enrich.server_url");
+            enrichService = new ExternalServiceSolrFieldEnricher(serverUrl, solrFieldInRequest);       
+           log.info("Solr field enrich service initialised with url='{}' and using request fields='{}'", serverUrl, solrFieldInRequest);         
+        }
+ 
+        
 
         // FIXME DUMP CONFIG OPTIONS
         // ConfigPrinter.print(conf);
@@ -165,6 +179,9 @@ public class WARCIndexerCommand {
         Instrument.timeRel("WARCIndexerCommand.main#total",
                            "WARCIndexerCommand.parseWarcFiles#startup", start);
 
+     
+        
+        
         // Loop through each Warc files
         for (int arcsIndex = 0; arcsIndex < opts.inputFiles.length; arcsIndex++) {
             final long arcStart = System.nanoTime();
@@ -214,7 +231,8 @@ public class WARCIndexerCommand {
                                    "WARCIndexerCommand.parseWarcFiles#solrdocCreation", recordStart);
                 if (doc != null) {
                     if (!opts.onlyRootPages || (doc.getFieldValue(SolrFields.SOLR_URL_TYPE) != null &&
-                                        doc.getFieldValue(SolrFields.SOLR_URL_TYPE).equals(SolrFields.SOLR_URL_TYPE_SLASHPAGE))) {
+                                        doc.getFieldValue(SolrFields.SOLR_URL_TYPE).equals(SolrFields.SOLR_URL_TYPE_SLASHPAGE))) {                     
+                        enrichFromExternalService(conf, enrichService, doc); // If enabled in config.                                                
                         docConsumer.add(doc);
                         recordCount++;
                         //System.out.println(doc.getSolrDocument()); Will log every solr document to output. Only for debugging
@@ -224,14 +242,9 @@ public class WARCIndexerCommand {
                         inFile.getName() + " @" + rec.getHeader().getOffset()); //All request records will log this. It is expected there is no document.
             }
       
-              //Optional enrich 
+              
 
-              //TODO handle if not exists, method takes no default value(!?)  
-              String enabledProptery="warc.enrich.enabled";
-              boolean hasProperty=conf.hasPath("warc.enrich.enabled");
-              System.out.println("has property:"+hasProperty);
-              boolean enrich_enabled=conf.getBoolean("warc.enrich.enabled");
-              System.out.println("enrich:"+enrich_enabled);                        
+
             }
                 
       
@@ -246,6 +259,39 @@ public class WARCIndexerCommand {
 
         long endTime = System.currentTimeMillis();
         System.out.println("WARC Indexer Finished in " + ((endTime - startTime) / 1000.0) + " seconds.");
+    }
+
+    
+    /**
+     * This method will enrich or overwrite Solr fields with values from an external service just before submitting the document to solr.
+     * Can be enabled in the config3.xml by property: warc.enric.enabled=true
+     * The service will be called as a POST request with a JSON object with key/values from Solr fields. Defined as list in warc.enrich.solrFieldsInRequest 
+     * The JSON response (key-values) will overwrite Solr fields. Define which fields to overwrite in warc.enrich.solrFieldsInRequest.jsonFieldsInResponse  
+     */
+    private static void enrichFromExternalService(Config conf, ExternalServiceSolrFieldEnricher enrichService, SolrRecord doc) {
+        final long start = System.nanoTime();
+        Instrument.timeRel("WARCIndexer.extract#total","WARCIndexer.extract#external.service", start);
+        //Instrument.timeRel("WARCIndexerCommand.main#total","WARCIndexerCommand.enrich#startup", start);
+        //TODO handle if not exists, method takes no default value(!?)  
+        if(enrichService!= null) { //Will have been initialized at startup
+
+            List<String> solrFieldInRequest = conf.getStringList("warc.enrich.solrFieldsInRequest");
+            HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();
+            try {
+                //Send parameters in request
+                for (String field : solrFieldInRequest) {       
+                    jsonRequestParameters.put(field, doc.getFieldAsString(field));                    
+                }                                                      
+                HashMap<String, String> solrFieldsValues = enrichService.extractEnrichFields(jsonRequestParameters);
+                //Add or overwrite solrfields
+                for (String field: solrFieldsValues.keySet()) {
+                    doc.setField(field,solrFieldsValues.get(field)); //will overwrite. (setField and not addField)
+                }                
+            }
+            catch(Exception e) {
+               log.error("Error enrich Solr field from service call. Request parameters:"+jsonRequestParameters +" Error:"+e.getMessage());
+            }                    
+        }
     }
     
 }

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -270,10 +270,8 @@ public class WARCIndexerCommand {
      */
     private static void enrichFromExternalService(Config conf, ExternalServiceSolrFieldEnricher enrichService, SolrRecord doc) {
         final long start = System.nanoTime();
-        Instrument.timeRel("WARCIndexer.extract#total","WARCIndexer.extract#external.service", start);
-        //Instrument.timeRel("WARCIndexerCommand.main#total","WARCIndexerCommand.enrich#startup", start);
-        //TODO handle if not exists, method takes no default value(!?)  
-        if(enrichService!= null) { //Will have been initialized at startup
+        Instrument.timeRel("WARCIndexer.extract#total","WARCIndexer.extract#external.service", start);  
+        if(enrichService!= null) { //Will have been initialized at startup if enabled in config3.xml
 
             List<String> solrFieldInRequest = conf.getStringList("warc.enrich.solrFieldsInRequest");
             HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -238,14 +238,9 @@ public class WARCIndexerCommand {
                 } else {
                     log.debug("No document produced by record: " + type + " for url " + url + " from " + 
                         inFile.getName() + " @" + rec.getHeader().getOffset()); //All request records will log this. It is expected there is no document.
+              }
             }
-      
-              
-
-
-            }
-                
-      
+                      
             docConsumer.endWARC();
             Instrument.timeRel("WARCIndexerCommand.main#total",
                                "WARCIndexerCommand.parseWarcFiles#fullarcprocess", arcStart);

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -285,7 +285,7 @@ public class WARCIndexerCommand {
                 //Add or overwrite solrfields
                 for (String field: solrFieldsValues.keySet()) {
                     String solrValue=solrFieldsValues.get(field);
-                    if (solrValue != null) {
+                    if (solrValue != null && !"null".equals(solrValue)) {//json service should not return null value
                        log.debug("Enriching with solr field:"+field +" value:"+solrValue);                
                        doc.setField(field,solrValue); //will overwrite. (setField and not addField)
                     }

--- a/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
+++ b/src/main/java/uk/bl/wa/indexer/WARCIndexerCommand.java
@@ -146,8 +146,8 @@ public class WARCIndexerCommand {
         //Set up external service solr field enricher if defined in property-file
         ExternalServiceSolrFieldEnricher enrichService=null;
         String enrichPropertyEnabled="warc.enrich.enabled";
-        boolean enrich_enabled=conf.getBoolean(enrichPropertyEnabled);
-        if (enrich_enabled) {            
+        boolean enrichDefined=conf.hasPath("warc.enrich.enabled");        
+        if (enrichDefined && conf.getBoolean(enrichPropertyEnabled)) { //Defined and true                       
             List<String> solrFieldInRequest = conf.getStringList("warc.enrich.solrFieldsInRequest");
             String serverUrl= conf.getString("warc.enrich.server_url");
             enrichService = new ExternalServiceSolrFieldEnricher(serverUrl, solrFieldInRequest);       

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 {
     "warc" : {
-        "title" : "Default indexer config2."
+        "title" : "Default indexer config for unittests (reference.conf) "
         # Indexing configuration:
         "index" : {
             # What to extract:

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -279,7 +279,7 @@
         # Enrich service example, see https://github.com/natliblux/warc-safe         
            
          "enrich":{
-            "enabled": true, # Enable it here to make it active.
+            "enabled": false, # Enable it here to make it active.
             "server_url":"http://localhost:8000/test_all"              
             "solrField2JsonFields" : [
                 ## Define mapping from solr fields to json attributes for external service call          

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -290,8 +290,8 @@
             "jsonFields2SolrFields" : [ # Case sensitive. Must be defined in solr schema (schema.xml)               
                ## Define mapping from JSON response to Solr fields.
                "nsfw_score -> nsfw_probability",
-               "is_nsfw -> is_nsfw",  ## NEEDS NEW FIELD IN RESPONSE
-               "is_virus -> is_virus", ## NEEDS NEW FIELD IN RESPONSE
+               "is_nsfw -> is_nsfw",
+               "is_virus -> is_virus",
                "av_details -> virus_description"            
             ]            
          }       

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,6 +1,6 @@
 {
     "warc" : {
-        "title" : "Default indexer config."
+        "title" : "Default indexer config2."
         # Indexing configuration:
         "index" : {
             # What to extract:
@@ -266,6 +266,36 @@
             #"host" : explorer.bl.uk,
             #"port" : 3127
         }
+        
+            # Enrich Solr fields. Call a webservice with POST request to enrich Solr fields with additional data.
+        #        
+        # The JSON response will overwrite the Solr fields with the values from the response. Define which values to overwrite in the 'jsonFields2SolrFields' list below.
+        # Values will only be overwritten if it is contained in the response and field is defined in 'jsonFields2SolrFields' field list   
+        # The service will be called for each record in the WARC-file. POST data will be a JSON object with key/value from the fully populated Solr document.
+        # Define the list of Solr fields extracted and what each field is mapped to as json in the 'solrField2JsonFields' list <br>
+        #
+        # The service must return a JSON object. Key/values will overwrite the Solr fields if they are present in the response. <br>      
+        # Fields must be defined in the schema.xml and configuration uploaded to Solr.    
+        # Enrich service example, see https://github.com/natliblux/warc-safe         
+           
+         "enrich":{
+            "enabled": true, # Enable it here to make it active.
+            "server_url":"http://localhost:8000/test_all"              
+            "solrField2JsonFields" : [
+                ## Define mapping from solr fields to json attributes for external service call          
+                ## Solr field name  -> json attribute name
+                "source_file_path -> file_path",                   
+                "source_file_offset -> offset"                
+            ],
+            "jsonFields2SolrFields" : [ # Case sensitive. Must be defined in solr schema (schema.xml)               
+               ## Define mapping from JSON response to Solr fields.
+               "nsfw_score -> nsfw_probability",
+               "is_nsfw -> is_nsfw",  ## NEEDS NEW FIELD IN RESPONSE
+               "is_virus -> is_virus", ## NEEDS NEW FIELD IN RESPONSE
+               "av_details -> virus_description"            
+            ]            
+         }       
+        
     }
 }
     

--- a/src/main/solr/solr9/discovery/conf/schema.xml
+++ b/src/main/solr/solr9/discovery/conf/schema.xml
@@ -366,8 +366,9 @@ This schema is for Solr 7+ and will not work under Solr 6.
         <field name="arc_harvesttime"      type="string" />
 
      
-        <!-- Additional custom fields from the BnL (National Library of Luxembourg)  -->
-        <!-- Currently under development for the WARC-indexer to call services for custom fields  -->
+        <!-- Additional custom field if safe-warc service is called to enrich solr fields (from version 3.5) -->
+        <!-- Enable service call in config3.xml -->
+        <!-- See: https://github.com/natliblux/warc-safe -->
         <field name="nsfw_probability" type="float" />
         <field name="is_nsfw" type="boolean" />
         <field name="is_virus" type="boolean" />

--- a/src/main/solr/solr9/discovery/conf/schema.xml
+++ b/src/main/solr/solr9/discovery/conf/schema.xml
@@ -365,6 +365,15 @@ This schema is for Solr 7+ and will not work under Solr 6.
         <field name="arc_harvest"          type="string" />
         <field name="arc_harvesttime"      type="string" />
 
+     
+        <!-- Additional custom fields from the BnL (National Library of Luxembourg)  -->
+        <!-- Currently under development for the WARC-indexer to call services for custom fields  -->
+        <field name="nsfw_probability" type="float" />
+        <field name="is_nsfw" type="boolean" />
+        <field name="is_virus" type="boolean" />
+        <field name="virus_description" type="string" />
+        
+
         <!-- Dynamic fields intended for intstitution-specific fields without changing the schema.
              (yes, the arc_*-fields above should have been dynamic fields instead of hardcoded)
               TODO: Add DocValues-enabled variants (take care not to change existing definitions) -->

--- a/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
+++ b/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
@@ -43,8 +43,12 @@ public class ExternalServiceSolrFieldEnricherIntegrationTest {
         
         String json= enrichService.generateJsonObject(jsonRequestParameters);               
         System.out.println("POST json to service:"+json);
-        String jsonResponse = enrichService.callService( json);
+        String jsonResponse = enrichService.callService( json);        
         System.out.println("Service response:"+jsonResponse);
+        if(jsonResponse==null) {
+            System.out.println("Error, empty/null response from service call;");
+            return;
+        }
         HashMap<String, String> jsonFromService = enrichService.parseJsonMapToJavaMap(jsonResponse);        
         System.out.println("Json fields in response:"+jsonFromService);
         HashMap<String, String> solrFields = enrichService.extractSolrFieldsFromResponse(jsonFromService);

--- a/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
+++ b/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
@@ -25,11 +25,12 @@ public class ExternalServiceSolrFieldEnricherIntegrationTest {
             System.out.println(map);
         }
         
+        System.out.println("");
         System.out.println("jsonField2SolrField mapping:");
         for (String map: jsonFields2SolrFieldsList) {
             System.out.println(map);
         }
-        
+        System.out.println("");
         String serverUrl= conf.getString("warc.enrich.server_url");                        
         System.out.println("Service url:"+serverUrl);
         ExternalServiceSolrFieldEnricher enrichService = new ExternalServiceSolrFieldEnricher(serverUrl,  solrField2JsonFields,jsonFields2SolrFieldsList);          
@@ -46,7 +47,7 @@ public class ExternalServiceSolrFieldEnricherIntegrationTest {
         HashMap<String, String> jsonFromService = enrichService.parseJsonMapToJavaMap(jsonResponse);        
         System.out.println("Json fields in response:"+jsonFromService);
         HashMap<String, String> solrFields = enrichService.extractSolrFieldsFromResponse(jsonFromService);
-        System.out.println("solr fields:"+solrFields);
+        System.out.println("Fields send to Solr:"+solrFields);
         
         
     }

--- a/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
+++ b/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
@@ -16,6 +16,7 @@ public class ExternalServiceSolrFieldEnricherIntegrationTest {
      */
     public static void main(String[] args) throws Exception{    
         Config conf = ConfigFactory.load(); //This will load the reference.conf file.
+        //Service call is not enabled, but we are testing each step here, not indexing a warc.
         
         List<String> solrField2JsonFields= conf.getStringList("warc.enrich.solrField2JsonFields");
         List<String> jsonFields2SolrFieldsList = conf.getStringList("warc.enrich.jsonFields2SolrFields");                        

--- a/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
+++ b/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
@@ -4,31 +4,37 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
 public class ExternalServiceSolrFieldEnricherIntegrationTest {
-    
 
     /**
-     *  Convenience main method to manual call and test an external webservice. Easy to run from IDE. 
+     *  Convenience main method to manual call and test an external webservice. Easy to run from IDE.
+     *  The method will do the same steps as the the getSolrEnrichmentFields method in ExternalServiceSolrFieldEnricher.
+     *   
      */
     public static void main(String[] args) throws Exception{    
-        //String url="http://localhost:8000/warc-safe/test_nsfw"; //If no clamAV is installed
-        String url="http://localhost:8000/test_all"; //Must be running
-
-        //Define field mapping from solr fields to service
-        List<String> solrFields2ToJsonAttributes=  new ArrayList<String>(); // This is the fields that will be extracted from the response(if present)
-        solrFields2ToJsonAttributes.add("source_file_path  -> file_path");
-        solrFields2ToJsonAttributes.add("source_file_offset -> offset");
+        Config conf = ConfigFactory.load(); //This will load the reference.conf file.
         
-        //Define field mapping from service to solr fields
-        List<String> jsonAttributes2SolrFields=  new ArrayList<String>();; // This is the fields that will be extracted from the response(if present)        
-        jsonAttributes2SolrFields.add("nsfw_score -> nsfw_probability");
-        jsonAttributes2SolrFields.add("is_nsfw -> is_nsfw"); //Still not implemented in service
-        jsonAttributes2SolrFields.add("is_virus  ->  is_virus"); //Still not implemented in service
-        jsonAttributes2SolrFields.add("av_details  -> virus_description");
-                       
-        ExternalServiceSolrFieldEnricher enrichService= new ExternalServiceSolrFieldEnricher(url,solrFields2ToJsonAttributes,jsonAttributes2SolrFields);
-
-        //Test single warc entry
+        List<String> solrField2JsonFields= conf.getStringList("warc.enrich.solrField2JsonFields");
+        List<String> jsonFields2SolrFieldsList = conf.getStringList("warc.enrich.jsonFields2SolrFields");                        
+        
+        System.out.println("solrField2Json fields mapping:");
+        for (String map:solrField2JsonFields) {
+            System.out.println(map);
+        }
+        
+        System.out.println("jsonField2SolrField mapping:");
+        for (String map: jsonFields2SolrFieldsList) {
+            System.out.println(map);
+        }
+        
+        String serverUrl= conf.getString("warc.enrich.server_url");                        
+        System.out.println("Service url:"+serverUrl);
+        ExternalServiceSolrFieldEnricher enrichService = new ExternalServiceSolrFieldEnricher(serverUrl,  solrField2JsonFields,jsonFields2SolrFieldsList);          
+        
+        //Test single warc entry. Change for test
         HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();
         jsonRequestParameters.put("file_path","/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000003.warc");
         jsonRequestParameters.put("offset","682189");
@@ -41,6 +47,8 @@ public class ExternalServiceSolrFieldEnricherIntegrationTest {
         System.out.println("Json fields in response:"+jsonFromService);
         HashMap<String, String> solrFields = enrichService.extractSolrFieldsFromResponse(jsonFromService);
         System.out.println("solr fields:"+solrFields);
+        
+        
     }
 
 }

--- a/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
+++ b/src/test/java/uk/bl/wa/indexer/ExternalServiceSolrFieldEnricherIntegrationTest.java
@@ -1,0 +1,46 @@
+package uk.bl.wa.indexer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+public class ExternalServiceSolrFieldEnricherIntegrationTest {
+    
+
+    /**
+     *  Convenience main method to manual call and test an external webservice. Easy to run from IDE. 
+     */
+    public static void main(String[] args) throws Exception{    
+        //String url="http://localhost:8000/warc-safe/test_nsfw"; //If no clamAV is installed
+        String url="http://localhost:8000/test_all"; //Must be running
+
+        //Define field mapping from solr fields to service
+        List<String> solrFields2ToJsonAttributes=  new ArrayList<String>(); // This is the fields that will be extracted from the response(if present)
+        solrFields2ToJsonAttributes.add("source_file_path  -> file_path");
+        solrFields2ToJsonAttributes.add("source_file_offset -> offset");
+        
+        //Define field mapping from service to solr fields
+        List<String> jsonAttributes2SolrFields=  new ArrayList<String>();; // This is the fields that will be extracted from the response(if present)        
+        jsonAttributes2SolrFields.add("nsfw_score -> nsfw_probability");
+        jsonAttributes2SolrFields.add("is_nsfw -> is_nsfw"); //Still not implemented in service
+        jsonAttributes2SolrFields.add("is_virus  ->  is_virus"); //Still not implemented in service
+        jsonAttributes2SolrFields.add("av_details  -> virus_description");
+                       
+        ExternalServiceSolrFieldEnricher enrichService= new ExternalServiceSolrFieldEnricher(url,solrFields2ToJsonAttributes,jsonAttributes2SolrFields);
+
+        //Test single warc entry
+        HashMap<String,String> jsonRequestParameters = new HashMap<String,String>();
+        jsonRequestParameters.put("file_path","/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000003.warc");
+        jsonRequestParameters.put("offset","682189");
+        
+        String json= enrichService.generateJsonObject(jsonRequestParameters);               
+        System.out.println("POST json to service:"+json);
+        String jsonResponse = enrichService.callService( json);
+        System.out.println("Service response:"+jsonResponse);
+        HashMap<String, String> jsonFromService = enrichService.parseJsonMapToJavaMap(jsonResponse);        
+        System.out.println("Json fields in response:"+jsonFromService);
+        HashMap<String, String> solrFields = enrichService.extractSolrFieldsFromResponse(jsonFromService);
+        System.out.println("solr fields:"+solrFields);
+    }
+
+}

--- a/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
+++ b/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
@@ -13,9 +13,9 @@ public class WarcIndexerCommandInvoker {
         WARCIndexerCommand.main(new String[]{
                 "-c", "conf/config3.conf",
                 "-s", "http://localhost:8983/solr/netarchivebuilder",
-               // new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
+             //  new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
                 //instead  of above you can use full path to file outside project
-                "/home/teg/solrwayback/warcs/430016-411-20230819220008345-00014-kb-prod-har-016.kb.dk.warc.gz"
+                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000006.warc"
         });
     }
 }

--- a/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
+++ b/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
@@ -13,9 +13,9 @@ public class WarcIndexerCommandInvoker {
         WARCIndexerCommand.main(new String[]{
                 "-c", "conf/config3.conf",
                 "-s", "http://localhost:8983/solr/netarchivebuilder",
-                new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
+               // new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
                 //instead  of above you can use full path to file outside project
-                //"home/xxx/warcs/warc1.warc.gz"
+                "/home/teg/solrwayback/warcs/430016-411-20230819220008345-00014-kb-prod-har-016.kb.dk.warc.gz"
         });
     }
 }

--- a/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
+++ b/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
@@ -15,7 +15,7 @@ public class WarcIndexerCommandInvoker {
                 "-s", "http://localhost:8983/solr/netarchivebuilder",
              //  new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
                 //instead  of above you can use full path to file outside project
-                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000008.warc"
+                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000010.warc"
         });
     }
 }

--- a/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
+++ b/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
@@ -15,7 +15,7 @@ public class WarcIndexerCommandInvoker {
                 "-s", "http://localhost:8983/solr/netarchivebuilder",
              //  new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
                 //instead  of above you can use full path to file outside project
-                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000006.warc"
+                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000007.warc"
         });
     }
 }

--- a/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
+++ b/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
@@ -15,7 +15,7 @@ public class WarcIndexerCommandInvoker {
                 "-s", "http://localhost:8983/solr/netarchivebuilder",
              //  new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
                 //instead  of above you can use full path to file outside project
-                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000010.warc"
+                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000012.warc"
         });
     }
 }

--- a/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
+++ b/src/test/java/uk/bl/wa/indexer/WarcIndexerCommandInvoker.java
@@ -15,7 +15,7 @@ public class WarcIndexerCommandInvoker {
                 "-s", "http://localhost:8983/solr/netarchivebuilder",
              //  new File(Thread.currentThread().getContextClassLoader().getResource("IAH-20080430204825-00000-blackbook-truncated.warc.gz").getFile()).getAbsolutePath()
                 //instead  of above you can use full path to file outside project
-                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000007.warc"
+                "/home/teg/solrwayback/warcs_webkid_filtered/DENMARK-EXTRACTED-2000-part-00000008.warc"
         });
     }
 }


### PR DESCRIPTION
Easy testing:
The class ExternalServiceSolrFieldEnricher can test a single call to the webservice (using config3.xml in the project) and will log the outcome. Enable the service in config3.xml. It is default disabled.
Also for testing indexing a whole warc-file, you just run the class WarcIndexerCommandInvoker (and have a solr running with the new fields).

For Solr you can download newest (pre-release) Solrwayback bundle and just use the solr folder and start it.(./solr start -c) . It has the 4 new fields defined: https://github.com/netarchivesuite/solrwayback/releases/tag/5.4.3-SNAPSHOT

The config in config3.xml should be easy to understand:
```

 "enrich":{
            "enabled": false, # Enable it here to make it active.
            "server_url":"http://localhost:8000/test_all"              
            "solrField2JsonFields" : [
                ## Define mapping from solr fields to json attributes for external service call          
                ## Solr field name  -> json attribute name
                "source_file_path -> file_path",                   
                "source_file_offset -> offset"                
            ],
            "jsonFields2SolrFields" : [ # Case sensitive. Must be defined in solr schema (schema.xml)               
               ## Define mapping from JSON response to Solr fields.
               "nsfw_score -> nsfw_probability",
               "is_nsfw -> is_nsfw", 
               "is_virus -> is_virus", 
               "av_details -> virus_description"            
            ]            
         }
```         
         
But the service must also return boolean values for is_nsfw/is_virus. (And have probability limit for NSFW threshold.)